### PR TITLE
Cleanup?

### DIFF
--- a/injector.js
+++ b/injector.js
@@ -14,4 +14,10 @@ chrome.webRequest.onBeforeSendHeaders.addListener(function (details) {
         value: cid
     });
     return { requestHeaders: details.requestHeaders };
-}, { urls: [ "<all_urls>" ], types: [ "main_frame" ] }, [ 'requestHeaders', 'blocking' ]);
+}, {
+    urls: [
+        "https://api.twitch.tv/*",
+        "https://tmi.twitch.tv/*"
+    ],
+    types: [ "main_frame" ]
+}, [ 'requestHeaders', 'blocking' ]);

--- a/manifest.json
+++ b/manifest.json
@@ -31,5 +31,10 @@
         "page": "options.html",
         "chrome_style": true
     },
-    "content_security_policy": "script-src 'self'; default-src 'self'"
+    "content_security_policy": "script-src 'self'; default-src 'self'",
+    "applications": {
+        "gecko": {
+            "strict_min_version": "52a1"
+        }
+    }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "version": "1.1.1",
     "icons": {
         "150": "icon.png"
-    }
+    },
 
     "browser_action": {
         "default_icon": {

--- a/manifest.json
+++ b/manifest.json
@@ -4,9 +4,14 @@
     "name": "Twitch Client ID Injector",
     "description": "Automatically includes your client ID whenever you use the Twitch API in your browser",
     "version": "1.1.1",
+    "icons": {
+        "150": "icon.png"
+    }
 
     "browser_action": {
-        "default_icon": "icon.png",
+        "default_icon": {
+            "150": "icon.png"
+        },
         "default_popup": "options.html"
     },
     "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
     "name": "Twitch Client ID Injector",
     "description": "Automatically includes your client ID whenever you use the Twitch API in your browser",
-    "version": "1.1",
+    "version": "1.1.1",
 
     "browser_action": {
         "default_icon": "icon.png",
@@ -14,6 +14,8 @@
         "activeTab",
         "webRequest",
         "webRequestBlocking",
+        "https://api.twitch.tv/",
+        "https://tmi.twitch.tv/",
         "https://api.twitch.tv/"
     ],
     "background": {
@@ -25,5 +27,5 @@
         "page": "options.html",
         "chrome_style": true
     },
-    "content_security_policy": "script-src 'self' chrome-extension-resource: 'unsafe-eval'; default-src 'self'"
+    "content_security_policy": "script-src 'self'; default-src 'self'"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -15,8 +15,7 @@
         "webRequest",
         "webRequestBlocking",
         "https://api.twitch.tv/",
-        "https://tmi.twitch.tv/",
-        "https://api.twitch.tv/"
+        "https://tmi.twitch.tv/"
     ],
     "background": {
         "scripts": [


### PR DESCRIPTION
This patch removes unnecessary CSP directive contents and adds tmi to the URLs that get the client ID injected. I've also taken the liberty to update the icon format the the non-deprecated one.

On a side-note this would also work on Firefox if it were not for `chrome.storage.sync` (which will hopefully be implemented by Firefox 53, which is quite a bit off). Most importantly this patch removes `unsafe-eval` from the CSP, which makes it actually possible to pass a review for addons.mozilla.org.

I've tested it in Chromium 53.0 on Linux and a slightly modified version (replaced sync with local) on Firefox 49. I don't know how to test extensions on Edge and haven't found any documentation for it, though in theory with `chrome.storage.local` it should work there too. And I don't have Opera installed and don't plan to ;)